### PR TITLE
WIP: Add Github Action to publish cache image

### DIFF
--- a/.github/workflows/docker-build-cache.yaml
+++ b/.github/workflows/docker-build-cache.yaml
@@ -32,4 +32,4 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/cache:${{ env.BRANCH }}
             ghcr.io/${{ github.repository }}/cache:${{ env.SHA }}
-            ${{ env.BRANCH == 'main' && format('ghcr.io/{0}/cache:latest', github.repository) || '' }}
+            ${{ env.BRANCH == 'master' && format('ghcr.io/{0}/cache:latest', github.repository) || '' }}

--- a/.github/workflows/docker-build-cache.yaml
+++ b/.github/workflows/docker-build-cache.yaml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image consisting of npm packages when yarn.lock is updated
+
+on:
+  push:
+    paths:
+      - "yarn.lock"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract branch name and SHA
+        run: |
+          echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          target: builder-base
+          tags: |
+            ghcr.io/${{ github.repository }}/cache:${{ env.BRANCH }}
+            ghcr.io/${{ github.repository }}/cache:${{ env.SHA }}
+            ${{ env.BRANCH == 'main' && format('ghcr.io/{0}/cache:latest', github.repository) || '' }}


### PR DESCRIPTION
Putting this as draft since the Github runner currently can't access the SIROS NPM registry.
This can later be referenced in the Dockerfile, or:
docker build --cache-from ghcr.io/malach-it/wallet-frontend/cache:latest or
docker build --cache-from ghcr.io/malach-it/wallet-frontend/cache:branchname